### PR TITLE
Minor ergonomic improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ func example() error {
         return err
     }
 
-    // Nil Filter value {} means full table scan, 
+    // Nil Filter value {} means full table scan,
     it, err := drv.Read(ctx, "db1", "coll1", driver.Filter(`{"Key1" : "vK1"}`), nil)
     if err != nil {
         return err
@@ -71,4 +71,11 @@ func example() error {
 ```
 
 # License
+
 This software is licensed under the [Apache 2.0](LICENSE).
+
+## Development
+
+1. sh scripts/install_build_deps.sh
+2. sh scripts/install_test_deps.sh
+3. make test

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ func example() error {
         return err
     }
 
-    // Nil Filter value {} means full table scan,
+    // Nil Filter value {} means full table scan.
     it, err := drv.Read(ctx, "db1", "coll1", driver.Filter(`{"Key1" : "vK1"}`), nil)
     if err != nil {
         return err

--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/tigrisdata/tigrisdb-client-go/driver"
 )
@@ -67,8 +68,13 @@ func (c *client) CreateDatabaseIfNotExist(
 	name string,
 	opts ...*driver.DatabaseOptions,
 ) error {
-	// TODO: Is this run transactionally?
-	if err := c.driver.CreateDatabase(ctx, name, opts...); err != nil {
+	err := c.driver.CreateDatabase(ctx, name, opts...)
+	if err != nil {
+		// TODO: Replace this with proper error handling
+		if strings.Contains(err.Error(), "already exists") {
+			return nil
+		}
+
 		return fmt.Errorf("error creating database: %w", err)
 	}
 	return nil

--- a/client/client.go
+++ b/client/client.go
@@ -70,7 +70,7 @@ func (c *client) CreateDatabaseIfNotExist(
 ) error {
 	err := c.driver.CreateDatabase(ctx, name, opts...)
 	if err != nil {
-		// TODO: Replace this with proper error handling
+		// TODO: Replace this with proper error handling.
 		if strings.Contains(err.Error(), "already exists") {
 			return nil
 		}

--- a/client/database.go
+++ b/client/database.go
@@ -19,8 +19,8 @@ type TxFunc func(
 ) (interface{}, error)
 
 // Tx is the interface for a client-level transaction. It does
-// not expose operations like Commit()/Abort as its meant to be used within
-// the Transact() method which abstracts away those operations.
+// not expose operations like Commit()/Abort as it is meant to be used
+// within the Transact() method which abstracts away those operations.
 type Tx interface {
 	driver.CRUDTx
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -54,7 +54,12 @@ type Driver interface {
 // Tx object is used to atomically modify documents.
 // This object is returned by BeginTx
 type Tx interface {
-	CommitableTx
+	// Commit all the modification of the transaction
+	Commit(ctx context.Context) error
+
+	// Rollback discard all the modification made by the transaction
+	Rollback(ctx context.Context) error
+
 	CRUDTx
 }
 
@@ -84,15 +89,6 @@ type CRUDTx interface {
 
 	// ListCollections lists collections in the database.
 	ListCollections(ctx context.Context, options ...*CollectionOptions) ([]string, error)
-}
-
-// CommitableTx is the interface that encapsulate the Commit()/Rollback portions of the transaction API.
-type CommitableTx interface {
-	// Commit all the modification of the transaction
-	Commit(ctx context.Context) error
-
-	// Rollback discard all the modification made by the transaction
-	Rollback(ctx context.Context) error
 }
 
 type driver struct {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -66,17 +66,11 @@ type CRUDTx interface {
 	// Replace array of documents into specified database and collection
 	// Creates document if it doesn't exist.
 	Replace(ctx context.Context, collection string, docs []Document, options ...*ReplaceOptions) (ReplaceResponse, error)
-<<<<<<< Updated upstream
-	// Read documents from the collection matching the specified filter
-	Read(ctx context.Context, collection string, filter Filter, fields Fields, options ...*ReadOptions) (Iterator, error)
-	// Update documents in the collection matching the speficied filter
-=======
 
 	// Read documents from the collection matching the specified filter.
 	Read(ctx context.Context, collection string, filter Filter, options ...*ReadOptions) (Iterator, error)
 
 	// Update documents in the collection matching the speficied filter.
->>>>>>> Stashed changes
 	Update(ctx context.Context, collection string, filter Filter, fields Fields, options ...*UpdateOptions) (UpdateResponse, error)
 
 	// Delete documents from the collection matching specified filter.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -54,27 +54,51 @@ type Driver interface {
 // Tx object is used to atomically modify documents.
 // This object is returned by BeginTx
 type Tx interface {
-	// Insert array of documents into specified database and collection
+	CommitableTx
+	CRUDTx
+}
+
+// CRUDTx is the interface that encapsulates the CRUD portions of the transaction API.
+type CRUDTx interface {
+	// Insert array of documents into specified database and collection.
 	Insert(ctx context.Context, collection string, docs []Document, options ...*InsertOptions) (InsertResponse, error)
+
 	// Replace array of documents into specified database and collection
-	// Creates document if it doesn't exist
+	// Creates document if it doesn't exist.
 	Replace(ctx context.Context, collection string, docs []Document, options ...*ReplaceOptions) (ReplaceResponse, error)
+<<<<<<< Updated upstream
 	// Read documents from the collection matching the specified filter
 	Read(ctx context.Context, collection string, filter Filter, fields Fields, options ...*ReadOptions) (Iterator, error)
 	// Update documents in the collection matching the speficied filter
+=======
+
+	// Read documents from the collection matching the specified filter.
+	Read(ctx context.Context, collection string, filter Filter, options ...*ReadOptions) (Iterator, error)
+
+	// Update documents in the collection matching the speficied filter.
+>>>>>>> Stashed changes
 	Update(ctx context.Context, collection string, filter Filter, fields Fields, options ...*UpdateOptions) (UpdateResponse, error)
-	// Delete documents from the collection matching specified filter
+
+	// Delete documents from the collection matching specified filter.
 	Delete(ctx context.Context, collection string, filter Filter, options ...*DeleteOptions) (DeleteResponse, error)
+
+	// CreateOrUpdateCollection either creates a collection or update the collection with the new schema.
+	CreateOrUpdateCollection(ctx context.Context, collection string, schema Schema, options ...*CollectionOptions) error
+
+	// DropCollection deletes the collection and all documents it contains.
+	DropCollection(ctx context.Context, collection string, options ...*CollectionOptions) error
+
+	// ListCollections lists collections in the database.
+	ListCollections(ctx context.Context, options ...*CollectionOptions) ([]string, error)
+}
+
+// CommitableTx is the interface that encapsulate the Commit()/Rollback portions of the transaction API.
+type CommitableTx interface {
 	// Commit all the modification of the transaction
 	Commit(ctx context.Context) error
+
 	// Rollback discard all the modification made by the transaction
 	Rollback(ctx context.Context) error
-	// CreateOrUpdateCollection either creates a collection or update the collection with the new schema
-	CreateOrUpdateCollection(ctx context.Context, collection string, schema Schema, options ...*CollectionOptions) error
-	// DropCollection deletes the collection and all documents it contains
-	DropCollection(ctx context.Context, collection string, options ...*CollectionOptions) error
-	// ListCollections lists collections in the database
-	ListCollections(ctx context.Context, options ...*CollectionOptions) ([]string, error)
 }
 
 type driver struct {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -68,7 +68,7 @@ type CRUDTx interface {
 	Replace(ctx context.Context, collection string, docs []Document, options ...*ReplaceOptions) (ReplaceResponse, error)
 
 	// Read documents from the collection matching the specified filter.
-	Read(ctx context.Context, collection string, filter Filter, options ...*ReadOptions) (Iterator, error)
+	Read(ctx context.Context, collection string, filter Filter, fields Fields, options ...*ReadOptions) (Iterator, error)
 
 	// Update documents in the collection matching the speficied filter.
 	Update(ctx context.Context, collection string, filter Filter, fields Fields, options ...*UpdateOptions) (UpdateResponse, error)


### PR DESCRIPTION
1. Return an error if the provided directory doesn't have any `.json` files inside of it instead of silently doing nothing.
2. Ignore "database already exists" errors in the `CreateDatabaseIfNotExist' method.
3. Pass `client.Tx` instead of `driver.Tx` in `Transact()` callback function.