### PR TITLE
Fields projection builder

### DIFF
--- a/projection/projection.go
+++ b/projection/projection.go
@@ -1,0 +1,43 @@
+package projection
+
+import (
+	"encoding/json"
+
+	"github.com/tigrisdata/tigrisdb-client-go/driver"
+)
+
+type Projection map[string]bool
+
+func Builder() Projection {
+	return Projection{}
+}
+
+func (pr Projection) Include(field string) Projection {
+	pr[field] = true
+	return pr
+}
+
+func (pr Projection) Exclude(field string) Projection {
+	pr[field] = false
+	return pr
+}
+
+func (pr Projection) Build() (driver.Projection, error) {
+	if pr == nil || len(pr) == 0 {
+		return nil, nil
+	}
+	b, err := json.Marshal(pr)
+	return b, err
+}
+
+func Include(field string) Projection {
+	pr := map[string]bool{}
+	pr[field] = true
+	return pr
+}
+
+func Exclude(field string) Projection {
+	pr := map[string]bool{}
+	pr[field] = false
+	return pr
+}

--- a/projection/projection_test.go
+++ b/projection/projection_test.go
@@ -1,0 +1,37 @@
+package projection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tigrisdata/tigrisdb-client-go/driver"
+)
+
+func TestProjectionBasic(t *testing.T) {
+
+	cases := []struct {
+		name   string
+		fields Projection
+		exp    string
+		err    error
+	}{
+		{"nil", nil, ``, nil},
+		{"include_1", Include("a"), `{"a":true}`, nil},
+		{"exclude_1", Exclude("a"), `{"a":false}`, nil},
+		{"include_exclude", Include("a").Exclude("b"), `{"a":true,"b":false}`, nil},
+		{"exclude_include", Exclude("a").Include("b"), `{"a":false,"b":true}`, nil},
+		{"exclude_include_nested", Exclude("a.b.c").Include("b.c.d"), `{"a.b.c":false,"b.c.d":true}`, nil},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(t *testing.T) {
+			b, err := v.fields.Build()
+			assert.Equal(t, v.err, err)
+			assert.Equal(t, v.exp, string(b))
+		})
+	}
+
+	b, err := Builder().Build()
+	assert.NoError(t, err)
+	assert.Equal(t, driver.Projection(nil), b)
+}


### PR DESCRIPTION
Only dot notation for nested fields supported, for example:
```
{ "top.nested" : true }
```